### PR TITLE
Correct Windows Platform Detection

### DIFF
--- a/there/__init__.py
+++ b/there/__init__.py
@@ -15,7 +15,7 @@ from builtins import print as _print
 
 import os.path
 
-if platform.platform() != "Windows":
+if not platform.platform().startswith("Windows"):
     import syslog
 
 HOME = os.path.expanduser('~')


### PR DESCRIPTION
`platform.platform()` returns *Windows-10-10.0.22000-SP0* on Windows 11.  Original code `platform.platform() != "Windows"` will not work for Windows 11. Corrected code should detect any Windows version.